### PR TITLE
Allow building with singletons-2.7 (GHC 8.10)

### DIFF
--- a/debruijn/debruijn.cabal
+++ b/debruijn/debruijn.cabal
@@ -69,6 +69,9 @@ library
                        TypeFamilies
                        TypeOperators
                        UndecidableInstances
+  if impl(ghc >= 8.10)
+   default-extensions: StandaloneKindSignatures
+                       CUSKs
 
   ghc-options:         -fwarn-incomplete-patterns
 


### PR DESCRIPTION
`singletons-2.7` now generates type families with `StandaloneKindSignatures`, which are only available on GHC 8.10 or later. I've enabled that extension additionally in the `.cabal` file along with `CUSKs`, to prevent the new kind inference algorithm that `StandaloneKindSignatures` uses from messing up other declarations in this repo that do not have standalone kind signatures.