### PR TITLE
Experiment with different representation for substitution.

### DIFF
--- a/debruijn/src/PolyScoped.hs
+++ b/debruijn/src/PolyScoped.hs
@@ -43,6 +43,13 @@ data Exp :: Nat -> Type where
 instance SubstDB Exp where
    var = VarE
 
+   rename s (IntE x)     = IntE x
+   rename s (VarE x)     = VarE (s x)
+   rename s (LamE ty e)  = LamE ty (rename (liftRename s) e)
+   rename s (AppE e1 e2) = AppE (rename s e1) (rename s e2)
+   rename s (TyLam e)    = TyLam (rename s e)  
+   rename s (TyApp e t)  = TyApp (rename s e) t
+
    subst s (IntE x)     = IntE x
    subst s (VarE x)     = applySub s x
    subst s (LamE ty e)  = LamE ty (subst (lift s) e)
@@ -63,9 +70,9 @@ substTy s (TyApp e t)  = TyApp (substTy s e) (W.subst s t)
 
 -- | Increment all types in an expression substitution
 incTy :: forall n m . Sub Exp n m -> Sub Exp n m 
-incTy (Inc x)     = Inc x
-incTy (e :< s1)   = substTy W.weakSub e :< incTy s1
-incTy (s1 :<> s2) = incTy s1 :<> incTy s2
+incTy Id        = Id
+incTy (e :< s1) = substTy W.weakSub e :< incTy s1
+incTy (Lift s)  = Lift (incTy s)
 
 
 -----------------------------------------------------------------------

--- a/debruijn/src/SimpleScoped.hs
+++ b/debruijn/src/SimpleScoped.hs
@@ -35,6 +35,11 @@ data Exp :: Nat -> Type where
 instance SubstDB Exp where
    var = VarE
 
+   rename f (IntE x)     = IntE x
+   rename f (VarE x)     = VarE (f x)
+   rename f (LamE ty e)  = LamE ty (rename (liftRename f) e)
+   rename f (AppE e1 e2) = AppE (rename f e1) (rename f e2)
+
    subst s (IntE x)     = IntE x
    subst s (VarE x)     = applySub s x
    subst s (LamE ty e)  = LamE ty (subst (lift s) e)

--- a/debruijn/src/SimpleTyped.hs
+++ b/debruijn/src/SimpleTyped.hs
@@ -32,6 +32,11 @@ data Exp :: [Ty] -> Ty -> Type where
 instance SubstDB Exp where
    var = VarE
 
+   rename s (IntE x)     = IntE x
+   rename s (VarE x)     = VarE (s x)
+   rename s (LamE ty e)  = LamE ty (rename (liftRename s) e)
+   rename s (AppE e1 e2) = AppE (rename s e1) (rename s e2)
+
    subst s (IntE x)     = IntE x
    subst s (VarE x)     = applySub s x
    subst s (LamE ty e)  = LamE ty (subst (lift s) e)


### PR DESCRIPTION
I was playing with some Agda and found another way to represent substitutions. 

It cannot represent all the substitutions the current representation can, but it's sufficient for what it is used.

I wonder if it's known. If it's not really, it would be interesting to add it (in a separate file), and run the benchmark against.

For what it is worth, it feels that proving facts about that representation might be easier, but I don't have enough experience to claim anything about that. At least splitting out renaming makes termination checker happier.
